### PR TITLE
add proposed fees message

### DIFF
--- a/proto/valorem/trade/v1/auth.proto
+++ b/proto/valorem/trade/v1/auth.proto
@@ -29,6 +29,3 @@ message NonceText {
 message VerifyText {
   string body = 1;
 }
-
-/** The empty message */
-message Empty {}

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package valorem.trade.v1;
+
+/* Service for getting Valorem Clear and Trade fee information. */
+service Fees {
+  // Returns the Valorem Fee structure.
+  rpc Fees(Empty) returns (FeesResponse);
+}
+
+message FeesResponse {
+  // A taker fee or rebate on notional value traded expressed in basis points.
+  int32 taker_fee_rebate_notional = 1;
+  // A maker fee or rebate on notional value traded expressed in basis points.
+  int32 maker_fee_rebate_notional = 2;
+  // A taker fee or rebate on premia or credit value traded expressed in basis points.
+  int32 taker_fee_rebate_premia_credit = 3;
+  // A maker fee or rebate on premia or credit value traded expressed in basis points.
+  int32 maker_fee_rebate_premia_credit = 4;
+  // A taker fee or rebate on spot value traded expressed in basis points.
+  int32 taker_fee_rebate_spot = 5;
+  // A maker fee or rebate on spot value traded expressed in basis points.
+  int32 maker_fee_rebate_spot = 6;
+  // A flat taker relayer fee or rebate expressed in USDC dust - used for non-valued offers/considerations
+  // such as NFTs.
+  int32 flat_maker_fee_rebate = 7;
+  // A flat maker relayer fee or rebate expressed in USDC dust - used for non-valued offers/considerations
+  // such as NFTs.
+  int32 flat_taker_fee_rebate = 8;
+  // A fee or rebate on notional value written via Clear expressed in basis points.
+  int32 clear_writer_notional_fee_rebate_bps = 9;
+  // A fee or rebate on notional value exercised via Clear expressed in basis points.
+  int32 clear_exercise_notional_fee_rebate_bps = 10;
+}

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -14,23 +14,23 @@ message FeeStructure {
    Fees maker = 1;
    Fees taker = 2;
    // A fee or rebate on notional value written via Clear expressed in basis points.
-   int32 clear_write_notional_fee_rebate_bps = 3;
+   int32 clear_write_notional_bps = 3;
    // A fee or rebate on underlying asset notional value redeemed via Clear expressed in basis points.
-   int32 clear_redeemed_notional_fee_rebate_bps = 4;
+   int32 clear_redeemed_notional_bps = 4;
    // A fee or rebate on notional value exercised via Clear expressed in basis points.
-   int32 clear_exercise_notional_fee_rebate_bps = 5;
-   // The address fees must be paid to.
-   H160 fee_address = 6;
+   int32 clear_exercise_notional_bps = 5;
+   // The address fees must be paid to or rebates are received from.
+   H160 address = 6;
 }
 
 message Fees {
   // A fee or rebate on notional value traded expressed in basis points.
-  int32 fee_rebate_notional = 1;
+  int32 notional_bps = 1;
   // A fee or rebate on premia or credit value traded expressed in basis points.
-  int32 fee_rebate_premia_credit = 2;
+  int32 premia_bps = 2;
   // A fee or rebate on spot value traded expressed in basis points.
-  int32 fee_rebate_spot = 3;
+  int32 spot_bps = 3;
   // A flat relayer fee or rebate expressed in 1e-6 USDC (dust)g - used for non-valued offers/considerations
   // such as NFTs.
-  int32 flat_fee_rebate = 4;
+  int32 flat = 4;
 }

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -22,3 +22,15 @@ message FeeStructure {
    // The address fees must be paid to.
    H160 fee_address = 6;
 }
+
+message Fees {
+  // A fee or rebate on notional value traded expressed in basis points.
+  int32 fee_rebate_notional = 1;
+  // A fee or rebate on premia or credit value traded expressed in basis points.
+  int32 fee_rebate_premia_credit = 2;
+  // A fee or rebate on spot value traded expressed in basis points.
+  int32 fee_rebate_spot = 3;
+  // A flat relayer fee or rebate expressed in USDC dust - used for non-valued offers/considerations
+  // such as NFTs.
+  int32 flat_fee_rebate = 4;
+}

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -7,10 +7,10 @@ package valorem.trade.v1;
 /* Service for getting Valorem Clear and Trade fee information. */
 service Fees {
   // Returns the Valorem Fee structure.
-  rpc Fees(Empty) returns (FeesResponse);
+  rpc getFeeStructure(Empty) returns (FeeStructure);
 }
 
-message FeesResponse {
+message FeeStructure {
   // A taker fee or rebate on notional value traded expressed in basis points.
   int32 taker_fee_rebate_notional = 1;
   // A maker fee or rebate on notional value traded expressed in basis points.
@@ -33,4 +33,6 @@ message FeesResponse {
   int32 clear_writer_notional_fee_rebate_bps = 9;
   // A fee or rebate on notional value exercised via Clear expressed in basis points.
   int32 clear_exercise_notional_fee_rebate_bps = 10;
+  // The address fees must be paid to.
+  H160 fee_address = 11;
 }

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -27,7 +27,7 @@ message Fees {
   // A fee or rebate on notional value traded expressed in basis points.
   int32 notional_bps = 1;
   // A fee or rebate on premia or credit value traded expressed in basis points.
-  int32 premia_bps = 2;
+  int32 premium_bps = 2;
   // A fee or rebate on spot value traded expressed in basis points.
   int32 spot_bps = 3;
   // A flat relayer fee or rebate expressed in 1e-6 USDC (dust)g - used for non-valued offers/considerations

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -11,28 +11,14 @@ service Fees {
 }
 
 message FeeStructure {
-  // A taker fee or rebate on notional value traded expressed in basis points.
-  int32 taker_fee_rebate_notional = 1;
-  // A maker fee or rebate on notional value traded expressed in basis points.
-  int32 maker_fee_rebate_notional = 2;
-  // A taker fee or rebate on premia or credit value traded expressed in basis points.
-  int32 taker_fee_rebate_premia_credit = 3;
-  // A maker fee or rebate on premia or credit value traded expressed in basis points.
-  int32 maker_fee_rebate_premia_credit = 4;
-  // A taker fee or rebate on spot value traded expressed in basis points.
-  int32 taker_fee_rebate_spot = 5;
-  // A maker fee or rebate on spot value traded expressed in basis points.
-  int32 maker_fee_rebate_spot = 6;
-  // A flat taker relayer fee or rebate expressed in USDC dust - used for non-valued offers/considerations
-  // such as NFTs.
-  int32 flat_maker_fee_rebate = 7;
-  // A flat maker relayer fee or rebate expressed in USDC dust - used for non-valued offers/considerations
-  // such as NFTs.
-  int32 flat_taker_fee_rebate = 8;
-  // A fee or rebate on notional value written via Clear expressed in basis points.
-  int32 clear_writer_notional_fee_rebate_bps = 9;
-  // A fee or rebate on notional value exercised via Clear expressed in basis points.
-  int32 clear_exercise_notional_fee_rebate_bps = 10;
-  // The address fees must be paid to.
-  H160 fee_address = 11;
+   Fees maker = 1;
+   Fees taker = 2;
+   // A fee or rebate on notional value written via Clear expressed in basis points.
+   int32 clear_write_notional_fee_rebate_bps = 3;
+   // A fee or rebate on underlying asset notional value redeemed via Clear expressed in basis points.
+   int32 clear_redeemed_notional_fee_rebate_bps = 4;
+   // A fee or rebate on notional value exercised via Clear expressed in basis points.
+   int32 clear_exercise_notional_fee_rebate_bps = 5;
+   // The address fees must be paid to.
+   H160 fee_address = 6;
 }

--- a/proto/valorem/trade/v1/fees.proto
+++ b/proto/valorem/trade/v1/fees.proto
@@ -30,7 +30,7 @@ message Fees {
   int32 fee_rebate_premia_credit = 2;
   // A fee or rebate on spot value traded expressed in basis points.
   int32 fee_rebate_spot = 3;
-  // A flat relayer fee or rebate expressed in USDC dust - used for non-valued offers/considerations
+  // A flat relayer fee or rebate expressed in 1e-6 USDC (dust)g - used for non-valued offers/considerations
   // such as NFTs.
   int32 flat_fee_rebate = 4;
 }

--- a/proto/valorem/trade/v1/types.proto
+++ b/proto/valorem/trade/v1/types.proto
@@ -40,3 +40,6 @@ message EthSignature {
   bytes s = 2;
   bytes v = 3;
 }
+
+/** The empty message */
+message Empty {}


### PR DESCRIPTION
This service will return the fee structure for using Valorem Clear and Trade. So that users can calculate relayer and other fees more easily when forming orders.